### PR TITLE
fix issue if julia already installed

### DIFF
--- a/tb3py/main.py
+++ b/tb3py/main.py
@@ -36,6 +36,13 @@ julia_bin = os.path.join(
     "julia-1.6.1",
     "bin",
 )  # mpath+"/src/julia/julia-1.6.1/bin/julia" # path for julia
+
+if not os.path.exists(julia_bin):
+    print("using preinstalled julia")
+    julia_cmd = "julia"
+    julia_bin = "julia"
+
+
 os.environ["PATH"] += os.pathsep + os.path.join(julia_bin)
 # print(os.environ["PATH"])
 jlsession = Julia(runtime=julia_cmd, compiled_modules=False, sysimage=sysimage)


### PR DESCRIPTION
the tb3py code was assuming that it had to install julia and looking for the file it installed.

However, if julia is pre-installed by the user then it can use the default "julia" command.

