### PR TITLE
hamiltonian functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This code is only the wrapper that downloads and installs that code.
 There are several other examples provided to calculate total energies, electronic bandstructures, density of states, forces on atoms, vacancy and surface formation energies in the repo also.
 More details and documentation will be available soon.
 
-You can either use the python functions defined in main.py to access julia functions, or access the julia functions directly as demonstrated in [this example][tb3py/examples/example_using_julia_functions_directly.py]
+You can either use the python functions defined in main.py to access julia functions, or access the julia functions directly as demonstrated in [this example](tb3py/examples/example_using_julia_functions_directly.py)
 
 ## Performance Tips
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ This code is only the wrapper that downloads and installs that code.
 There are several other examples provided to calculate total energies, electronic bandstructures, density of states, forces on atoms, vacancy and surface formation energies in the repo also.
 More details and documentation will be available soon.
 
+You can either use the python functions defined in main.py to access julia functions, or access the julia functions directly as demonstrated in [this example][tb3py/examples/example_using_julia_functions_directly.py]
+
 ## Performance Tips
 
 - Julia can take advantage multiple threads. Try setting the environment variable below as appropriate for your machine.

--- a/README.md
+++ b/README.md
@@ -77,10 +77,13 @@ This code is only the wrapper that downloads and installs that code.
   python tb3py/main.py --cif_file tb3py/examples/JVASP-1002.cif
   ```
 
-There are several other examples provided to calculate total energies, electronic bandstructures, density of states, forces on atoms, vacancy and surface formation energies in the repo also.
-More details and documentation will be available soon.
+There are several other examples provided to calculate total energies,
+electronic bandstructures, density of states, forces on atoms, vacancy
+and surface formation energies in the repo also.  More details and
+documentation will be available soon.
 
-You can either use the python functions defined in main.py to access julia functions, or access the julia functions directly as demonstrated in [this example](tb3py/examples/example_using_julia_functions_directly.py)
+You can either use the python functions defined in main.py to access julia functions, 
+or access the julia functions directly as demonstrated in [this example](tb3py/examples/example_using_julia_functions_directly.py)
 
 ## Performance Tips
 

--- a/tb3py/examples/example_using_julia_functions_directly.py
+++ b/tb3py/examples/example_using_julia_functions_directly.py
@@ -1,0 +1,31 @@
+import tb3py.main as tb3
+
+#this example shows how to use the julia commands directly in python.
+#it is also possible to access some of these commands with a more pythonic
+#interface using functions defined in main.py
+
+#make crystal object from POSCAR
+
+c = tb3.TB.makecrys("POSCAR")
+
+# calculate energy
+
+#energy, tbc, flag = tb3.TB.scf_energy(c)
+
+# calculate energy force stress
+
+energy, f_cart, stress, tbc = tb3.TB.scf_energy_force_stress(c)
+
+print("PYTHON: energy is ", energy, " eV")
+print()
+print("PYTHON: force")
+print(f_cart)
+print()
+print("PYTHON: stress")
+print(stress)
+
+# All julia commands can be used directly this way, including plotting.
+# See https://pages.nist.gov/ThreeBodyTB.jl/ for documenation
+
+#for example 
+#tb3.TB.BandStruct.plot_bands(tbc)

--- a/tb3py/examples/example_using_julia_functions_directly.py
+++ b/tb3py/examples/example_using_julia_functions_directly.py
@@ -28,4 +28,4 @@ print(stress)
 # See https://pages.nist.gov/ThreeBodyTB.jl/ for documenation
 
 #for example 
-#tb3.TB.BandStruct.plot_bands(tbc)
+#tb3.TB.BandStruct.plot_bandstr(tbc)


### PR DESCRIPTION
creates two new functions. get_twobody_hamiltonian strictly gets the twobody terms between two atoms seperated by the vector R

get_hamiltonian_dict gets the entire real-space hamiltonian and makes it into a dictionary so it is easier to access orbitals, etc

Also, I created an example to show how to use the python interface to access the julia functions directly, as an alternative to the python functions defined in main.